### PR TITLE
修改禁言API的错误调用

### DIFF
--- a/YhUserSDK/openapi.py
+++ b/YhUserSDK/openapi.py
@@ -103,13 +103,13 @@ class api:
     @classmethod
     def ban_request(cls, user_id, group_id, time):
         """禁言请求方法"""
-        allow_time = ["10", "1h", "6h", "12h", "0"]
+        allow_time = [600, 3600, 21600, 43200, 0]
         if time not in allow_time:
             return {'success': False, 'code': -4, 'message': f"不支持的时间: {time}", 'data': None}
         
-        url = cls.base_url + "/group/gag_member"
-        data = {"groupId": group_id, "userId": user_id, "time": time}
-        action = "取消禁言" if time == "0" else "禁言"
+        url = cls.base_url + "/group/gag-member"
+        data = {"groupId": group_id, "userId": user_id, "gap": time}
+        action = "取消禁言" if time == 0 else "禁言"
         return cls._make_request(url, data, action)
 
     @classmethod


### PR DESCRIPTION
原禁言API的请求地址错误，
刚才抓包发现新的请求参数为：

{
  "groupId":  group_id,
  "userId": "user_id",
  "gag": 43200
}
![image](https://github.com/user-attachments/assets/ae55bf3a-ceb2-4930-90e4-5c386bed3852)

其中gag为秒数，仅支持云湖内10min，1h，6h，12h，0
分别对应秒数已修改